### PR TITLE
Fix duplicate `identified_by` key in "Titles" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,7 @@ In Linked Art titles are also considered identifiers. We thus use the same patte
           "_label": "Preferred terms"
         }
       ]
-    }
-  ],
-  "identified_by": [
+    },
     {
       "type": "Name",
       "content": "Zeezicht in Scheveningen",


### PR DESCRIPTION
We were working through the examples and noticed this one had a duplicate key, which is invalid JSON. Not sure if this is the right fix, but I figured I'd submit the PR for feedback. Thanks for the thorough docs!